### PR TITLE
Support macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ peekprof -pid 53432 -parent
 
 ## Support
 
-Current support is for **Linux** only.
+Current support is for **Linux** and **OSX**.

--- a/app.go
+++ b/app.go
@@ -108,7 +108,7 @@ func (a *App) watchMemoryUsage(wg *sync.WaitGroup) {
 				if !ok {
 					break LOOP
 				}
-				fmt.Printf("memory usage: %d mb\n", pstats.MemoryUsage.Rss/1024)
+				fmt.Printf("memory usage: %d mb\ncpu usage: %f%%", pstats.MemoryUsage.Rss/1024, pstats.CpuUsage.Percentage)
 				a.extractor.Add(extractors.ProcessStatsData{
 					MemoryUsage: extractors.MemoryUsageData{
 						Rss:     pstats.MemoryUsage.Rss,

--- a/internal/extractors/chartExtractor.go
+++ b/internal/extractors/chartExtractor.go
@@ -3,6 +3,7 @@ package extractors
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/go-echarts/go-echarts/v2/charts"
@@ -127,17 +128,20 @@ func (m *ChartExtractor) generateMemoryUsageChart() *charts.Line {
 	)
 
 	rssLine := m.getRssLineData()
-	vszLine := m.getRssSwapLineData()
 	timeParts := len(m.Data)
 	timeXAxis := m.DivideTimeIntoParts(timeParts)
 
 	// Put data into instance
 	line.SetXAxis(timeXAxis).
 		AddSeries("RSS", rssLine, charts.WithLabelOpts(opts.Label{Show: true, Position: "top"})).
-		AddSeries("RSS + Swap", vszLine, charts.WithLabelOpts(opts.Label{Show: true, Position: "top"})).
 		SetSeriesOptions(
 			charts.WithLineChartOpts(opts.LineChart{Smooth: true}),
 		)
+
+	if runtime.GOOS != "darwin" {
+		rssSwapLine := m.getRssSwapLineData()
+		line.AddSeries("RSS + Swap", rssSwapLine, charts.WithLabelOpts(opts.Label{Show: true, Position: "top"}))
+	}
 
 	return line
 }

--- a/internal/extractors/csvExtractor.go
+++ b/internal/extractors/csvExtractor.go
@@ -44,11 +44,20 @@ func (c *CsvMemoryUsage) records() [][]string {
 	records := make([][]string, len(c.Data))
 
 	for i := 0; i < len(c.Data); i++ {
-		r := []string{
-			c.Data[i].Timestamp.Local().Format(time.RFC3339),
-			fmt.Sprintf("%d", c.Data[i].MemoryUsage.Rss),
-			fmt.Sprintf("%d", c.Data[i].MemoryUsage.RssSwap),
-			fmt.Sprintf("%.1f", c.Data[i].CpuUsage.Percentage),
+		var r []string
+		if runtime.GOOS != "darwin" {
+			r = []string{
+				c.Data[i].Timestamp.Local().Format(time.RFC3339),
+				fmt.Sprintf("%d", c.Data[i].MemoryUsage.Rss),
+				fmt.Sprintf("%d", c.Data[i].MemoryUsage.RssSwap),
+				fmt.Sprintf("%.1f", c.Data[i].CpuUsage.Percentage),
+			}
+		} else {
+			r = []string{
+				c.Data[i].Timestamp.Local().Format(time.RFC3339),
+				fmt.Sprintf("%d", c.Data[i].MemoryUsage.Rss),
+				fmt.Sprintf("%.1f", c.Data[i].CpuUsage.Percentage),
+			}
 		}
 		records[i] = r
 	}

--- a/internal/extractors/csvExtractor.go
+++ b/internal/extractors/csvExtractor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 )
 
@@ -30,7 +31,13 @@ func (c *CsvMemoryUsage) Add(data ProcessStatsData) error {
 }
 
 func (c *CsvMemoryUsage) headers() []string {
-	return []string{"timestamp", "rss kb", "rss+swap kb", "cpu%"}
+	var headers []string
+	if runtime.GOOS != "darwin" {
+		headers = []string{"timestamp", "rss kb", "cpu%"}
+	} else {
+		headers = []string{"timestamp", "rss kb", "rss+swap kb", "cpu%"}
+	}
+	return headers
 }
 
 func (c *CsvMemoryUsage) records() [][]string {

--- a/internal/process/darwinProcess.go
+++ b/internal/process/darwinProcess.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -92,9 +93,13 @@ func (p *DarwinProcess) GetMemoryUsage() (MemoryUsage, error) {
 	if err != nil {
 		return emptymu, fmt.Errorf("failed getting process rss: %w", err)
 	}
-	rssSwap, err := p.GetRssWithSwap()
-	if err != nil {
-		return emptymu, fmt.Errorf("failed getting process rss with swap: %w", err)
+
+	var rssSwap int64
+	if runtime.GOARCH != "darwin" {
+		rssSwap, err = p.GetRssWithSwap()
+		if err != nil {
+			return emptymu, fmt.Errorf("failed getting process rss with swap: %w", err)
+		}
 	}
 
 	return MemoryUsage{
@@ -112,5 +117,5 @@ func (p *DarwinProcess) GetRss() (int64, error) {
 	return rss, nil
 }
 func (p *DarwinProcess) GetRssWithSwap() (int64, error) {
-	return p.GetRss()
+	return 0, fmt.Errorf("swap value is not supported for OSX")
 }

--- a/internal/process/darwinProcess.go
+++ b/internal/process/darwinProcess.go
@@ -1,6 +1,13 @@
 package process
 
-import "time"
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
 
 type DarwinProcess struct {
 	Pid int32
@@ -11,27 +18,116 @@ func NewDarwinProcess(pid int32) (*DarwinProcess, error) {
 }
 
 func (p *DarwinProcess) GetName() (string, error) {
-	return "", nil
+
+	return fmt.Sprintf("%d", p.Pid), nil
 }
-func (p *DarwinProcess) GetChildrenPids() ([]int32, error) {
-	return nil, nil
-}
-func (p *DarwinProcess) GetStats() (ProcessStats, error) {
-	return ProcessStats{}, nil
-}
+
 func (p *DarwinProcess) WatchStats(interval time.Duration) <-chan ProcessStats {
 	ch := make(chan ProcessStats)
+
+	go func() {
+		if interval == 0 {
+			panic("refresh interval must be non-zero")
+		}
+		defer close(ch)
+
+		tick := time.NewTicker(interval)
+		defer tick.Stop()
+
+		for range tick.C {
+			stats, err := p.GetStats()
+			if err != nil {
+				log.Fatalf("error getting stats: %v", err)
+			}
+
+			ch <- stats
+		}
+	}()
+
 	return ch
 }
+
+func (p *DarwinProcess) GetStats() (ProcessStats, error) {
+	emptyps := ProcessStats{}
+
+	memUsage, err := p.GetMemoryUsage()
+	if err != nil {
+		return emptyps, fmt.Errorf("failed getting memory usage: %w", err)
+	}
+
+	cpuUsage, err := p.GetCpuUsage()
+	if err != nil {
+		return emptyps, fmt.Errorf("failed getting cpu usage: %w", err)
+	}
+
+	return ProcessStats{
+		MemoryUsage: memUsage,
+		CpuUsage:    cpuUsage,
+	}, nil
+}
+
 func (p *DarwinProcess) GetCpuUsage() (CpuUsage, error) {
-	return CpuUsage{}, nil
+	emptycpu := CpuUsage{}
+
+	cmd := fmt.Sprintf(`ps -p %d -o %%cpu | awk 'FNR == 2 {gsub(/ /,""); print}'`, p.Pid)
+	out, err := exec.Command("bash", "-c", cmd).Output()
+	if err != nil {
+		return emptycpu, fmt.Errorf("failed to run command: %v", err)
+	}
+
+	if len(out) == 0 {
+		return emptycpu, fmt.Errorf("output from cpu usage command is empty")
+	}
+
+	outStr := strings.Trim(string(out), " \n")
+
+	cpuPercent64, err := strconv.ParseFloat(outStr, 32)
+	if err != nil {
+		return emptycpu, fmt.Errorf("failed to parse output to float: %w", err)
+	}
+	cpuPercent := float32(cpuPercent64)
+
+	return CpuUsage{
+		Percentage: cpuPercent,
+	}, nil
 }
 func (p *DarwinProcess) GetMemoryUsage() (MemoryUsage, error) {
-	return MemoryUsage{}, nil
+	emptymu := MemoryUsage{}
+
+	rss, err := p.GetRss()
+	if err != nil {
+		return emptymu, fmt.Errorf("failed getting process rss: %w", err)
+	}
+	rssSwap, err := p.GetRssWithSwap()
+	if err != nil {
+		return emptymu, fmt.Errorf("failed getting process rss with swap: %w", err)
+	}
+
+	return MemoryUsage{
+		Rss:     rss,
+		RssSwap: rssSwap,
+	}, nil
 }
 func (p *DarwinProcess) GetRss() (int64, error) {
-	return 0, nil
+	cmd := fmt.Sprintf("ps -p %d -o rss", p.Pid)
+	output, err := exec.Command("bash", "-c", cmd).Output()
+	if err != nil {
+		if err.Error() != "signal: interrupt" {
+			return 0, fmt.Errorf("failed executing command %s: %s", cmd, err)
+		}
+	}
+	output = []byte(strings.Trim(string(output), "\n "))
+	if len(output) == 0 {
+		return 0, nil
+	}
+
+	rss, err := strconv.ParseInt(string(output), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert output %q to int: %w", output, err)
+	}
+
+	return rss, nil
 }
 func (p *DarwinProcess) GetRssWithSwap() (int64, error) {
-	return 0, nil
+	return p.GetRss()
 }

--- a/internal/process/darwinProcess.go
+++ b/internal/process/darwinProcess.go
@@ -18,8 +18,14 @@ func NewDarwinProcess(pid int32) (*DarwinProcess, error) {
 }
 
 func (p *DarwinProcess) GetName() (string, error) {
+	cmd := fmt.Sprintf("ps -p %d -c -o cmd | awk 'FNR == 2 {print}", p.Pid)
+	output, err := exec.Command("bash", "-c", cmd).Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to execute command: %w", err)
+	}
+	outputStr := strings.TrimSpace(string(output))
 
-	return fmt.Sprintf("%d", p.Pid), nil
+	return outputStr, nil
 }
 
 func (p *DarwinProcess) WatchStats(interval time.Duration) <-chan ProcessStats {

--- a/internal/process/darwinProcess.go
+++ b/internal/process/darwinProcess.go
@@ -17,7 +17,7 @@ func NewDarwinProcess(pid int32) (*DarwinProcess, error) {
 }
 
 func (p *DarwinProcess) GetName() (string, error) {
-	cmd := fmt.Sprintf("ps -p %d -c -o cmd | awk 'FNR == 2 {print}", p.Pid)
+	cmd := fmt.Sprintf("ps -p %d -c -o cmd | awk 'FNR == 2 {print}'", p.Pid)
 	output, err := exec.Command("bash", "-c", cmd).Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to execute command: %w", err)

--- a/internal/process/darwinProcess.go
+++ b/internal/process/darwinProcess.go
@@ -17,7 +17,7 @@ func NewDarwinProcess(pid int32) (*DarwinProcess, error) {
 }
 
 func (p *DarwinProcess) GetName() (string, error) {
-	cmd := fmt.Sprintf("ps -p %d -c -o cmd | awk 'FNR == 2 {print}'", p.Pid)
+	cmd := fmt.Sprintf("ps -p %d -c -o command | awk 'FNR == 2 {print}'", p.Pid)
 	output, err := exec.Command("bash", "-c", cmd).Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to execute command: %w", err)

--- a/internal/process/linuxProcess.go
+++ b/internal/process/linuxProcess.go
@@ -189,21 +189,9 @@ func (p *LinuxProcess) GetStats() (ProcessStats, error) {
 func (p *LinuxProcess) GetCpuUsage() (CpuUsage, error) {
 	emptycpu := CpuUsage{}
 
-	cmd := fmt.Sprintf(`ps -p %d -o %%cpu | awk 'FNR == 2 {gsub(/ /,""); print}'`, p.Pid)
-	out, err := exec.Command("bash", "-c", cmd).Output()
+	cpuPercent64, err := getPsFloat(p.Pid, "%cpu")
 	if err != nil {
-		return emptycpu, fmt.Errorf("failed to run command: %v", err)
-	}
-
-	if len(out) == 0 {
-		return emptycpu, fmt.Errorf("output from cpu usage command is empty")
-	}
-
-	outStr := strings.Trim(string(out), " \n")
-
-	cpuPercent64, err := strconv.ParseFloat(outStr, 32)
-	if err != nil {
-		return emptycpu, fmt.Errorf("failed to parse output to float: %w", err)
+		return emptycpu, fmt.Errorf("failed to get cpu value: %w", err)
 	}
 	cpuPercent := float32(cpuPercent64)
 

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -2,7 +2,10 @@ package process
 
 import (
 	"fmt"
+	"os/exec"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -45,4 +48,49 @@ func NewProcess(pid int32) (Process, error) {
 	default:
 		panic(fmt.Sprintf("%s is not currently yet supported", runtime.GOOS))
 	}
+}
+
+func getPsString(pid int32, psKey string) (string, error) {
+	cmd := fmt.Sprintf(`ps -p %d -o %s | awk 'FNR == 2 {gsub(/ /,""); print}'`, pid, psKey)
+	fmt.Printf("cmd: %s\n", cmd)
+	output, err := exec.Command("bash", "-c", cmd).Output()
+	if err != nil {
+		if err.Error() != "signal: interrupt" {
+			return "", fmt.Errorf("failed executing command %s: %s", cmd, err)
+		}
+	}
+	outputStr := strings.Trim(string(output), "\n ")
+	if len(output) == 0 {
+		return "", nil
+	}
+
+	return outputStr, nil
+}
+
+func getPsInt(pid int32, psKey string) (int64, error) {
+	valueStr, err := getPsString(pid, psKey)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get ps string of type %s for pid %d: %w", psKey, pid, err)
+	}
+
+	value, err := strconv.ParseInt(string(valueStr), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert output %q to int: %w", valueStr, err)
+	}
+
+	return value, nil
+}
+
+func getPsFloat(pid int32, psKey string) (float64, error) {
+	valueStr, err := getPsString(pid, psKey)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get ps string of type %s for pid %d: %w", psKey, pid, err)
+	}
+
+	value, err := strconv.ParseFloat(string(valueStr), 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert output %q to float: %w", valueStr, err)
+	}
+
+	return value, nil
 }

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -52,7 +52,6 @@ func NewProcess(pid int32) (Process, error) {
 
 func getPsString(pid int32, psKey string) (string, error) {
 	cmd := fmt.Sprintf(`ps -p %d -o %s | awk 'FNR == 2 {gsub(/ /,""); print}'`, pid, psKey)
-	fmt.Printf("cmd: %s\n", cmd)
 	output, err := exec.Command("bash", "-c", cmd).Output()
 	if err != nil {
 		if err.Error() != "signal: interrupt" {

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -22,7 +22,6 @@ type ProcessStats struct {
 
 type Process interface {
 	GetName() (string, error)
-	GetChildrenPids() ([]int32, error)
 	GetStats() (ProcessStats, error)
 	WatchStats(interval time.Duration) <-chan ProcessStats
 	GetCpuUsage() (CpuUsage, error)
@@ -41,7 +40,6 @@ func NewProcess(pid int32) (Process, error) {
 		process, err := NewWindowsProcess(pid)
 		return process, err
 	case "darwin":
-		panic("osx is not currently yet supported")
 		process, err := NewDarwinProcess(pid)
 		return process, err
 	default:

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -50,6 +50,9 @@ func NewProcess(pid int32) (Process, error) {
 	}
 }
 
+// getPsString is equivelant of running ps -p %pid -o %psKey.
+// It's a command to get runtime information about a process.
+// It is supported only in Unix like systems, like Linux, FreeBSD and OSX
 func getPsString(pid int32, psKey string) (string, error) {
 	cmd := fmt.Sprintf(`ps -p %d -o %s | awk 'FNR == 2 {gsub(/ /,""); print}'`, pid, psKey)
 	output, err := exec.Command("bash", "-c", cmd).Output()


### PR DESCRIPTION
Add macos support which uses only the `ps` command to get a process' information and not directly from the `/proc/` linux supported directory.